### PR TITLE
fixed base64 ref in websocket.lua

### DIFF
--- a/lua/chrome-remote/websocket.lua
+++ b/lua/chrome-remote/websocket.lua
@@ -2,7 +2,7 @@ local uv = vim.loop
 local EventEmitter = require('chrome-remote.event_emitter')
 local websocket_codec = require('chrome-remote.websocket_codec')
 local http_codec = require('chrome-remote.http_codec')
-local base64_encode = require('lua.chrome-remote.base64').encode
+local base64_encode = require('chrome-remote.base64').encode
 
 local rshift = bit.rshift
 local band = bit.band


### PR DESCRIPTION
Installing it on the latest version of nvim (v0.10.4) there is an error on missing 'base64', which is due to the fact that the require inside websocket.lua had an extra 'lua.' prefix when importing base64 encode